### PR TITLE
fix backward navigation on ctrl+f search bar

### DIFF
--- a/pykib_base/mainWindow.py
+++ b/pykib_base/mainWindow.py
@@ -687,6 +687,6 @@ class MainWindow(QWidget):
     def searchOnPage(self):
         signalFrom = self.sender().objectName()
         if (signalFrom == "searchUpButton"):
-            self.page.findText(self.searchText.text(), QWebEnginePage.FindBackward)
+            self.page.findText(self.searchText.text(), QWebEnginePage.FindFlag.FindBackward)
         else:
             self.page.findText(self.searchText.text())


### PR DESCRIPTION
### Issue

Using the search bar and trying to navigate backwards (click on the "up" button) causes the browser process to crash instantly with the following exception:

    AttributeError: type object 'OWebEnginePage' has no attribute 'FindBackward'

Expected behavior should be pretty obvious.

### Steps to reproduce

Found on a _RangeeOS_ 12 system running _Pykib_ v3.0.43. Should apply to the latest version as well.

* run _Pykib_ with any web page
* press Ctrl+F to open the search bar
* press the "arrow up" button to search backwards

### Analysis

With scoped enums in Qt6 the shortcut `QWebEnginePage.FindBackward` is no longer valid.

### Proposed fix

Passing the qualified enum value `QWebEnginePage.FindFlag.FindBackward` [^1] to the `findText()` call seems to resolve this issue.


[^1]: https://doc.qt.io/qt-6/qwebenginepage.html#FindFlag-enum